### PR TITLE
Improve PyVista Dependency: Use vtk-base instead of full VTK

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - imageio >=2.5.0
     - pooch
-    - vtk
+    - vtk-base
     - scooby >=0.5.1
     - typing_extensions
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - pooch
     - vtk-base
     - scooby >=0.5.1
-    - vtk
 
 test:
   imports:


### PR DESCRIPTION
Due to [patenting concerns related to FFmpeg](https://www.ffmpeg.org/legal.html), it is not feasible for me or others in a similar situation to install the full VTK package for work-related purposes. It is likely that many others face this issue, though they may not be aware of it.

To address this problem, we have separated VTK into two packages: `vtk-base` and `vtk-io-ffmpeg`. This allows users to install only the components they require without potential legal complications.

In light of this, I propose that `pyvista` should depend on `vtk-base` instead of the full VTK package. Users who require FFmpeg functionality can simply install `vtk-io-ffmpeg` separately. This change would make `pyvista` more accessible to those facing similar patent constraints.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
