### PR TITLE
Update vtk-base upper bound to <9.7.0 to match upstream v0.47.0+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pooch
     - scooby >=0.5.1
     - typing-extensions
-    - vtk-base !=9.4.0,!=9.4.1,<9.6.0
+    - vtk-base !=9.4.0,!=9.4.1,<9.7.0
     - cyclopts >=4.0.0
 
 test:


### PR DESCRIPTION
PyVista v0.47.0 added VTK 9.6 support upstream (pyvista/pyvista#8228), bumping the constraint from `vtk <9.6.0` to `vtk <9.7.0`:

https://github.com/pyvista/pyvista/blob/v0.47.1/pyproject.toml#L27-L30

It looks like the auto-update bot bumped the feedstock to v0.47.0 and v0.47.1 but the `vtk-base` upper bound wasn't updated alongside.

Was the `<9.6.0` pin kept intentionally (e.g. known conda-specific issues with vtk-base 9.6), or was it simply missed during the version bump? If intentional, happy to close this.

If not, this one-line change aligns the feedstock constraint with the released upstream requirement, allowing pyvista to be installed alongside packages that depend on `vtk-base 9.6.x`.